### PR TITLE
Query Report: fix constants for server availability

### DIFF
--- a/GameSpy Research/Research On GameSpy Protocol.tex
+++ b/GameSpy Research/Research On GameSpy Protocol.tex
@@ -1680,10 +1680,9 @@ The response of available check is fixed with first 6 bytes, last byte is the st
 	\begin{tabular}{|l|m{5cm}|c|}
 		\hline
 		\textbf{Status}&\textbf{Description}&\textbf{Value}\\\hline
-		GSIACWaiting&still waiting for a response from the backend&1\\\hline
-		GSIACAvailable&the game's backend services are available&2\\\hline
-		GSIACUnavailable& the game's backend services are unavailable&3\\\hline
-		GSIACTemporarilyUnavailable&the game's backend services are temporarily unavailable&4\\\hline
+		Available&the game's backend services are available&0\\\hline
+		Unavailable& the game's backend services are unavailable&1\\\hline
+		TemporarilyUnavailable&the game's backend services are temporarily unavailable&2\\\hline
 	\end{tabular}
 \caption{Available check server status}
 \label{Available check server status}


### PR DESCRIPTION
The status reported by the server has direct relation to constants from the GameSpy SDK: the resulting constant is determined from several bits of the response.

This commit fixes the data that the server should report, and also renames the constants in the table to avoid any confusion.

Moreover, the UniSpyServer [has the correct definitions](https://github.com/GameProgressive/UniSpyServer/blob/96eb6f3e929da93d96e86f395edc6280cb13dd82/src/Servers/QueryReport/src/Entity/Enumerate/ServerAvailability.cs#L5-L7).